### PR TITLE
学習時間結果の表示

### DIFF
--- a/app/Http/Controllers/StudyChallengesController.php
+++ b/app/Http/Controllers/StudyChallengesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\MonthlyGoal;
+use App\Models\Study;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 
@@ -14,7 +15,15 @@ class StudyChallengesController extends Controller
         $monthlyGoal = MonthlyGoal::latest('updated_at')
         ->where('month', Carbon::now()->format('Y-m') . '-01')
         ->first(['target_hour', 'target_minutes']);
+
+        // studiesテーブルに保存されている月の総勉強時間を取得する
+        $totalStudyTime = Study::where('date', 'like', Carbon::now()->format('Y-m') . '%')
+        ->sum('duration');
+
+        // 総勉強時間を時と分に分解する
+        $resultHour = floor($totalStudyTime / 60);
+        $resultMinutes = $totalStudyTime % 60;
         
-        return view('study_challenges', compact('monthlyGoal'));
+        return view('study_challenges', compact('monthlyGoal', 'resultHour', 'resultMinutes'));
     }
 }

--- a/app/Models/Study.php
+++ b/app/Models/Study.php
@@ -8,16 +8,29 @@ use Illuminate\Database\Eloquent\Model;
 class Study extends Model
 {
 
-protected $guarded = ['id'];
+    protected $fillable = ['users_id', 'date', 'hour', 'minutes', 'subject', 'study_time', 'month', 'duration'];
 
-public function user()
-{
-    return $this->belongsTo('App\Models\User');
-}
 
-public function goal()
-{
-    return $this->hasOne('App\Models\Goal');
-}
+    protected $guarded = ['id'];
+
+    public function user()
+    {
+        return $this->belongsTo('App\Models\User');
+    }
+
+    public function goal()
+    {
+        return $this->hasOne('App\Models\Goal');
+    }
+
+    public function setStudyTimeAttribute($value)
+    {
+        $this->attributes['study_time'] = $value * 60;
+    }
+
+    public function getStudyTimeAttribute($value)
+    {
+        return $value / 60;
+    }
 
 }

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -14,6 +14,7 @@
         const subjects = JSON.parse(`{!! $subjects !!}`);
         const data = JSON.parse(`{!! $data !!}`);
 
+        //最新の7日分の日付を取得
         const truncatedDates = dates.slice(Math.max(dates.length - 7, 0));
 
         //日付ごとの学習時間を集計
@@ -108,3 +109,5 @@
     </script>
 </body>
 </html>
+
+<a href="/index" class="btn_return_index">メイン画面に戻る</a>

--- a/resources/views/study_challenges.blade.php
+++ b/resources/views/study_challenges.blade.php
@@ -3,7 +3,10 @@
 </div>
 
 <div>
-    <p>結果<input type="text" name="result_hour" value="">時間<input type="text" name="result_minutes" value="">分</p>
+    <p>結果
+        <input type="text" name="result_hour" value="{{ $resultHour }}" readonly>時間
+        <input type="text" name="result_minutes" value="{{ $resultMinutes }}" readonly>分
+    </p>
 </div>
 
 <a href="/study_challenges/new" class="btn_move_study_challenges_new">今月の目標時間を設定する</a>


### PR DESCRIPTION
プルリクエストあげましたので
 ご確認よろしくお願いいたします！

【実装内容】
目標画面の結果欄に今月の学習総時間を表示する機能を実装しました

【確認したこと】
目標画面のところで今月の学習総時間が結果欄に反映されているか確認しました。
また別の月に勉強した時間が結果欄に追加されていないことを確認しました。