### PR TITLE
退会機能の修正と目標時間表示の修正

### DIFF
--- a/app/Http/Controllers/SettingsWithdrawalController.php
+++ b/app/Http/Controllers/SettingsWithdrawalController.php
@@ -25,6 +25,7 @@ class SettingsWithdrawalController extends Controller
 
         if ($user) {
             $user->studies()->delete();
+            $user->monthlyGoals()->delete();
             $user->forceDelete();
             Auth::logout();
             $request->session()->invalidate();

--- a/app/Http/Controllers/StudyChallengesController.php
+++ b/app/Http/Controllers/StudyChallengesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\MonthlyGoal;
 use App\Models\Study;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 
@@ -11,13 +12,17 @@ class StudyChallengesController extends Controller
 {
     public function index()
     {   
+        $user = Auth::user();
+        $currentMonth = Carbon::now()->startOfMonth();
+        
         //monthly_goal_tableに保存されているtarget_hourとtarget_minutesを取得する
-        $monthlyGoal = MonthlyGoal::latest('updated_at')
-        ->where('month', Carbon::now()->format('Y-m') . '-01')
+        $monthlyGoal = MonthlyGoal::where('user_id', $user->id)
+        ->where('month', $currentMonth)
         ->first(['target_hour', 'target_minutes']);
 
         // studiesテーブルに保存されている月の総勉強時間を取得する
-        $totalStudyTime = Study::where('date', 'like', Carbon::now()->format('Y-m') . '%')
+        $totalStudyTime = Study::where('user_id', $user->id)
+        ->where('date', 'like', Carbon::now()->format('Y-m') . '%')
         ->sum('duration');
 
         // 総勉強時間を時と分に分解する

--- a/app/Http/Controllers/StudyChallengesNewController.php
+++ b/app/Http/Controllers/StudyChallengesNewController.php
@@ -22,6 +22,7 @@ class StudyChallengesNewController extends Controller
 
         //入力値をmonthly_goal_tableに保存する
         DB::table('monthly_goal')->insert([
+            'user_id' => $request->user()->id,
             'month' => date('Y-m') . '-01',
             'achieved' => false,
             'target_hour' => $target_hour,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany('App\Models\Study');
     }
 
+    public function monthlyGoals()
+    {
+        return $this->hasMany(MonthlyGoal::class);
+    }
+
     public function categories()
     {
         return $this->belongsToMany(Group::class);

--- a/database/migrations/2023_01_15_180101_create_monthly_goal_table.php
+++ b/database/migrations/2023_01_15_180101_create_monthly_goal_table.php
@@ -15,11 +15,14 @@ return new class extends Migration
     {
         Schema::create('monthly_goal', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('user_id');
             $table->date('month');
             $table->boolean('achieved')->default(false);
             $table->integer('target_hour');
             $table->integer('target_minutes');
             $table->timestamps();
+            //外部キー
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/database/migrations/2023_01_15_180103_create_studies_table.php
+++ b/database/migrations/2023_01_15_180103_create_studies_table.php
@@ -13,11 +13,6 @@ return new class extends Migration
      */
     public function up()
     {
-//         Schema::table('studies', function (Blueprint $table) {
-//         $table->dropForeign(['user_id']);
-//     });
-
-// }
         Schema::create('studies', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');


### PR DESCRIPTION
プルリクエストあげましたので
 ご確認よろしくお願いいたします！
 
【修正内容】
退会した時にmonthly_goalテーブルが削除されていなかったので、
削除するように修正しました

ユーザーごとに目標時間と結果時間が表示されておらず、共有して時間が表示されていたので
修正しました

【確認したこと】
退会した後、phpmyadminでmonthly_goalテーブルが削除されているか
ユーザーごとに目標時間と結果時間が表示されているか(共有されていないこと)
