### PR TITLE
Laravelのデフォルトエラー画面・登録画面を独自レイアウトに変更、Mailgunをsandboxから独自ドメインに切替

### DIFF
--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,31 +1,37 @@
-<x-guest-layout>
-    <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
-        {{ __('サインアップありがとうございます！始める前に、メールアドレスを確認してください。送信したリンクをクリックしてください。メールが届かない場合は、別のリンクをお送りします。') }}
-    </div>
+@extends('layouts.app')
 
-    @if (session('status') == 'verification-link-sent')
-        <div class="mb-4 font-medium text-sm text-green-600 dark:text-green-400">
-            {{ __('登録時に提供されたメールアドレスに新しい確認リンクが送信されました。') }}
-        </div>
-    @endif
+@section('content')
+    <div class="min-h-screen flex items-center justify-center">
+        <div class="text-center max-w-lg w-full px-4">
+            <h1 class="text-2xl font-bold text-gray-800 mb-4">メールアドレスの確認</h1>
 
-    <div class="mt-4 flex items-center justify-between">
-        <form method="POST" action="{{ route('verification.send') }}">
-            @csrf
+            <p class="text-gray-600 leading-relaxed mb-6">
+                ご登録ありがとうございます。<br>
+                ご入力いただいたメールアドレス宛に確認用メールを送信しました。<br>
+                メール内のリンクをクリックして認証を完了してください。
+            </p>
 
-            <div>
-                <x-primary-button>
-                    {{ __('確認メールを再送信する') }}
-                </x-primary-button>
+            @if (session('status') == 'verification-link-sent')
+                <div class="mb-6 font-medium text-green-600">
+                    新しい確認リンクをメールアドレスに送信しました。
+                </div>
+            @endif
+
+            <div class="flex flex-col sm:flex-row justify-center items-center gap-4">
+                <form method="POST" action="{{ route('verification.send') }}">
+                    @csrf
+                    <x-primary-button>
+                        メールを再送信する
+                    </x-primary-button>
+                </form>
+
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="underline text-sm text-gray-600 hover:text-gray-900">
+                        ログアウト
+                    </button>
+                </form>
             </div>
-        </form>
-
-        <form method="POST" action="{{ route('logout') }}">
-            @csrf
-
-            <button type="submit" class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
-                {{ __('ログアウト') }}
-            </button>
-        </form>
+        </div>
     </div>
-</x-guest-layout>
+@endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('title', 'ページが見つかりません')
+
+@section('content')
+    <div class="flex flex-col items-center justify-center min-h-[70vh] text-center px-4">
+        <h1 class="text-6xl font-bold text-red-500 mb-4">404</h1>
+        <p class="text-xl text-gray-700 mb-2">ページが見つかりません。</p>
+        <p class="text-gray-500 mb-6">お探しのページは削除されたか、URLが間違っている可能性があります。</p>
+        <a href="{{ url('/') }}" class="text-blue-600 underline hover:text-blue-800 transition">
+            トップページへ戻る
+        </a>
+    </div>
+@endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('title', 'システムエラー')
+
+@section('content')
+    <div class="flex flex-col items-center justify-center min-h-[70vh] text-center px-4">
+        <h1 class="text-6xl font-bold text-red-600 mb-4">500</h1>
+        <p class="text-xl text-gray-700 mb-2">内部サーバーエラーが発生しました。</p>
+        <p class="text-gray-500 mb-6">申し訳ありません。時間をおいて再度お試しください。</p>
+        <a href="{{ url('/') }}" class="text-blue-600 underline hover:text-blue-800 transition">
+            トップページへ戻る
+        </a>
+    </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,7 +15,6 @@
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
-            @include('layouts.navigation')
 
             <!-- Page Heading -->
             @if (isset($header))
@@ -28,7 +27,7 @@
 
             <!-- Page Content -->
             <main>
-                {{ $slot }}
+                @yield('content')
             </main>
         </div>
     </body>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -23,7 +23,7 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::user()->name }}</div>
+                            <div>{{ Auth::check() ? Auth::user()->name : 'ゲスト' }}</div>
 
                             <div class="ml-1">
                                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -75,8 +75,8 @@
         <!-- Responsive Settings Options -->
         <div class="pt-4 pb-1 border-t border-gray-200 dark:border-gray-600">
             <div class="px-4">
-                <div class="font-medium text-base text-gray-800 dark:text-gray-200">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
+                <div class="font-medium text-base text-gray-800 dark:text-gray-200">{{ Auth::check() ? Auth::user()->name : 'ゲスト' }}</div>
+                <div class="font-medium text-sm text-gray-500">{{ Auth::check() ? Auth::user()->email : 'ゲストユーザー' }}</div>
             </div>
 
             <div class="mt-3 space-y-1">


### PR DESCRIPTION
Laravelのデフォルトエラー画面・登録画面を独自レイアウトに変更
Mailgunをsandboxから独自ドメインに切替
sandboxドメインだと他の人から送られるメールアドレスに送信することができないので、
独自のドメインを取得して、そのドメインを利用してメール送信するようにしました。